### PR TITLE
Allow schema generation to handle nested Models of same name

### DIFF
--- a/changes/2240-adriangb.md
+++ b/changes/2240-adriangb.md
@@ -1,0 +1,1 @@
+BUG: fix Model name collision resolution in get_model_name_map by using the fully qualified name insted of just the name.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -404,7 +404,7 @@ def get_flat_models_from_models(models: Sequence[Type['BaseModel']]) -> TypeMode
 
 
 def get_long_model_name(model: TypeModelOrEnum) -> str:
-    return f'{model.__module__}__{model.__name__}'.replace('.', '__')
+    return f'{model.__module__}__{model.__qualname__}'.replace('.', '__')
 
 
 def field_type_schema(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2163,7 +2163,7 @@ from pydantic import BaseModel
 
 
 class External:
-    
+
     class Model(BaseModel):
         pass
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2151,7 +2151,11 @@ class MyModel(BaseModel):
     }
 
 
-def test_multiple_models_with_same_name_but_different_qualname(create_module):
+def test_model_name_map_clash_different_qualname(create_module):
+    """Test that get_model_name_map can handle Models that share
+    a name and are in the same module but have different fully
+    qualified names.
+    """
     module = create_module(
         # language=Python
         """
@@ -2170,4 +2174,4 @@ class Model(BaseModel):
     )
     unique_models = {module.External.Model, module.Model}
     res = get_model_name_map(unique_models)
-    assert res.keys() == unique_models
+    assert set(res.keys()) == unique_models

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2149,3 +2149,25 @@ class MyModel(BaseModel):
         f'{module_2.__name__}__MyEnum',
         f'{module_2.__name__}__MyModel',
     }
+
+
+def test_multiple_models_with_same_name_but_different_qualname(create_module):
+    module = create_module(
+        # language=Python
+        """
+from pydantic import BaseModel
+
+
+class External:
+    
+    class Model(BaseModel):
+        pass
+
+
+class Model(BaseModel):
+    pass
+        """
+    )
+    unique_models = {module.External.Model, module.Model}
+    res = get_model_name_map(unique_models)
+    assert res.keys() == unique_models


### PR DESCRIPTION
This allows the following:

```python
class External:
    class Model(BaseModel):
        pass

class Model(BaseModel):
    pass
```

To generate a valid OpenAPI schema in FastAPI.

I don't think this should break anything?